### PR TITLE
Accept s3Endpoint config variable

### DIFF
--- a/cloud/storage/s3/s3.go
+++ b/cloud/storage/s3/s3.go
@@ -33,9 +33,10 @@ const (
 
 // Keys used for storing dial options.
 const (
-	regionName = "s3Region"
-	bucketName = "s3BucketName"
-	defaultACL = "defaultACL"
+	regionName  = "s3Region"
+	bucketName  = "s3BucketName"
+	endpointURL = "s3Endpoint"
+	defaultACL  = "defaultACL"
 )
 
 // s3Impl is an implementation of Storage that connects to an Amazon Simple
@@ -55,6 +56,12 @@ func New(opts *storage.Opts) (storage.Storage, error) {
 	if !ok {
 		return nil, errors.E(op, errors.Invalid, errors.Errorf("%q option is required", regionName))
 	}
+	config := aws.Config{
+		Region: aws.String(region),
+	}
+	if endpoint, ok := opts.Opts[endpointURL]; ok {
+		config.Endpoint = aws.String(endpoint)
+	}
 	bucket, ok := opts.Opts[bucketName]
 	if !ok {
 		return nil, errors.E(op, errors.Invalid, errors.Errorf("%q option is required", bucketName))
@@ -69,7 +76,7 @@ func New(opts *storage.Opts) (storage.Storage, error) {
 	}
 
 	sess, err := session.NewSessionWithOptions(session.Options{
-		Config:            aws.Config{Region: aws.String(region)},
+		Config:            config,
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR makes it possible to set 's3Endpoint' in your AWS server config, which allows something like `s3Endpoint=https://nyc3.digitaloceanspaces.com` to set it up for [DO Spaces](https://www.digitalocean.com/products/object-storage/). To set the credentials you can use the standard aws credential options like environment variables


Fixes https://github.com/upspin/upspin/issues/509